### PR TITLE
Fix screen display issues

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1415,6 +1415,7 @@ function startGame(event) {
     }
   }
 
+  getDeck(player, bloodgateUser.startingDeck);
   getDeck(enemy, "bloodfury-dominion");
 
   if (settings.difficulty === "easy") {


### PR DESCRIPTION
The screen was fading to black after loading because the player's deck was never loaded in startGame(). Only the enemy deck was being loaded, which caused the game to crash when trying to initialize the player's hand, resulting in a black screen.

Fixed by adding getDeck(player, bloodgateUser.startingDeck) before the enemy deck load in the startGame() function.

Fixes #issue - screen fades to black after loading